### PR TITLE
[signUp] 회원가입 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ build/
 out/
 
 # hiding application.yaml
+
+# exclude dev file
 !src/main/resources/application-DEV.yaml

--- a/src/main/java/com/miniproject/user/controller/UserController.java
+++ b/src/main/java/com/miniproject/user/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.miniproject.user.controller;
+
+import com.miniproject.user.dto.SignUpRequestDto;
+import com.miniproject.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/user")
+@RestController
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/signup")
+    public ResponseEntity<String> signUp(SignUpRequestDto dto) {
+        userService.signUp(dto);
+        return ResponseEntity
+              .status(HttpStatus.CREATED)
+              .body("회원가입 완료!");
+    }
+
+}

--- a/src/main/java/com/miniproject/user/domain/User.java
+++ b/src/main/java/com/miniproject/user/domain/User.java
@@ -1,0 +1,54 @@
+package com.miniproject.user.domain;
+
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "users", indexes = {
+      @Index(columnList = "username"),
+      @Index(columnList = "nickname")
+})
+@Entity
+public class User {
+
+
+    @Column(nullable = false, unique = true)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, unique = true) private String username;
+    @Column(nullable = false) private String password;
+    @Column(nullable = false, unique = true) private String nickname;
+    @Column(nullable = false) private String profile;
+
+    @Column(updatable = false) @CreatedDate private LocalDateTime createdAt;
+    @Column(updatable = false) @CreatedBy private String createdBy;
+    @Column(insertable = false) @LastModifiedDate private LocalDateTime updatedAt;
+    @Column(insertable = false) @LastModifiedBy private String updatedBy;
+
+    protected User() {
+    }
+
+    public User(String username, String password, String nickname, String profile) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+        this.profile = profile;
+    }
+
+}

--- a/src/main/java/com/miniproject/user/dto/SignUpRequestDto.java
+++ b/src/main/java/com/miniproject/user/dto/SignUpRequestDto.java
@@ -1,0 +1,30 @@
+package com.miniproject.user.dto;
+
+import com.miniproject.user.domain.User;
+import java.io.Serializable;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public final class SignUpRequestDto implements Serializable {
+
+    @Email @NotBlank final String username;
+    @NotBlank final String password;
+    @NotBlank final String rePassword;
+    @NotBlank final String nickname;
+    final String profile;
+
+    public SignUpRequestDto(String username, String password, String rePassword, String nickname,
+          String profile) {
+        this.username = username;
+        this.password = password;
+        this.rePassword = rePassword;
+        this.nickname = nickname;
+        this.profile = profile;
+    }
+
+    public User toEntity() {
+        return new User(username, password, nickname, profile);
+    }
+}

--- a/src/main/java/com/miniproject/user/repository/UserRepository.java
+++ b/src/main/java/com/miniproject/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.miniproject.user.repository;
+
+import com.miniproject.user.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByNickname(String nickname);
+}

--- a/src/main/java/com/miniproject/user/service/NormalUserService.java
+++ b/src/main/java/com/miniproject/user/service/NormalUserService.java
@@ -1,0 +1,55 @@
+package com.miniproject.user.service;
+
+import com.miniproject.user.domain.User;
+import com.miniproject.user.dto.SignUpRequestDto;
+import com.miniproject.user.repository.UserRepository;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class NormalUserService implements UserService{
+
+    private final UserRepository userRepository;
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile(
+          "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,}$");
+
+    public NormalUserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional
+    public void signUp(SignUpRequestDto dto) {
+        validateUsername(dto);
+        validatePassword(dto);
+        validateDuplicateNickname(dto);
+
+        userRepository.save(dto.toEntity());
+    }
+
+    private void validateUsername(SignUpRequestDto dto) {
+        Optional<User> user = userRepository.findByUsername(dto.getUsername());
+        if (user.isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 계정입니다.");
+        }
+    }
+
+    private void validatePassword(SignUpRequestDto dto) {
+        if (!PASSWORD_PATTERN.matcher(dto.getPassword()).matches()) {
+            throw new IllegalArgumentException(("비밀번호는 최소 8자리에 숫자, 문자, 특수문자를 각각 1개 이상 포함해야 합니다."));
+        }
+        if (!dto.getPassword().equals(dto.getRePassword())) {
+            throw new IllegalArgumentException("비밀번호와 비밀번호 재확인이 일치하지 않습니다.");
+        }
+    }
+
+    private void validateDuplicateNickname(SignUpRequestDto dto) {
+        Optional<User> user = userRepository.findByNickname(dto.getNickname());
+        if (user.isPresent()) {
+            throw new IllegalArgumentException("중복되는 닉네임입니다.");
+        }
+    }
+}

--- a/src/main/java/com/miniproject/user/service/UserService.java
+++ b/src/main/java/com/miniproject/user/service/UserService.java
@@ -1,0 +1,8 @@
+package com.miniproject.user.service;
+
+import com.miniproject.user.dto.SignUpRequestDto;
+
+public interface UserService {
+
+    void signUp(SignUpRequestDto dto);
+}

--- a/src/main/resources/application-DEV.yaml
+++ b/src/main/resources/application-DEV.yaml
@@ -8,3 +8,7 @@ spring:
   h2:
     console:
       enabled: true
+
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/src/test/java/com/miniproject/user/service/UserServiceTest.java
+++ b/src/test/java/com/miniproject/user/service/UserServiceTest.java
@@ -1,0 +1,93 @@
+package com.miniproject.user.service;
+
+import com.miniproject.user.dto.SignUpRequestDto;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+public class UserServiceTest {
+
+    private static Validator validator;
+
+    @Autowired
+    private UserService userService;
+
+    @DisplayName(value = "회원 아이디 중복이 되어서는 안된다.")
+    @Test
+    void usernameDuplicationTest() {
+        SignUpRequestDto dto1 = new SignUpRequestDto("username@gmail.com", "password1!",
+              "password1!", "user1", null);
+        SignUpRequestDto dto2 = new SignUpRequestDto("username@gmail.com", "password1!",
+              "password1!", "user2", null);
+
+        Assertions.assertThatNoException().isThrownBy(() -> userService.signUp(dto1));
+        Assertions.assertThatIllegalArgumentException().isThrownBy(() -> userService.signUp(dto2))
+              .withMessageContaining("이미 존재하는 계정");
+    }
+
+    @DisplayName(value = "아이디가 이메일 형식을 지키는가?.")
+    @Test
+    void isUsernameEmailFormTest() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+        Set<ConstraintViolation<SignUpRequestDto>> result1 = validator.validate(
+              new SignUpRequestDto("username1@gmail.com", "password1!", "password1!", "user1",
+                    null));
+        Set<ConstraintViolation<SignUpRequestDto>> result2 = validator.validate(
+              new SignUpRequestDto("username2", "password1!", "password1!", "user2", null));
+
+        Assertions.assertThat(result1).isEmpty();
+        Assertions.assertThat(result2).isNotEmpty();
+    }
+
+    @DisplayName(value = "비밀번호와 비밀번호 재입력은 일치해야 한다.")
+    @Test
+    void passwordEqualsTest() {
+        SignUpRequestDto dto1 = new SignUpRequestDto("username@gmail.com", "password1!",
+              "password1!",
+              "user1", null);
+        SignUpRequestDto dto2 = new SignUpRequestDto("username1@gmail.com", "password2!",
+              "password1!",
+              "user2", null);
+
+        Assertions.assertThatCode(() -> userService.signUp(dto1)).doesNotThrowAnyException();
+        Assertions.assertThatIllegalArgumentException().isThrownBy(() -> userService.signUp(dto2))
+              .withMessageContaining("비밀번호 재확인");
+    }
+
+    @DisplayName(value = "비밀번호는 최소 8자리에 숫자, 문자, 특수문자를 각각 1개 이상 포함해야 한다")
+    @Test
+    void passwordRegexTest() {
+        SignUpRequestDto dto1 = new SignUpRequestDto("username1@gmail.com", "password1!",
+              "password1!", "user1", null);
+        SignUpRequestDto dto2 = new SignUpRequestDto("username2@gmail.com", "pw", "w",
+              "user2", null);
+
+        Assertions.assertThatNoException().isThrownBy(() -> userService.signUp(dto1));
+        Assertions.assertThatIllegalArgumentException().isThrownBy(() -> userService.signUp(dto2))
+              .withMessageContaining("8자리에 숫자, 문자, 특수문자");
+    }
+
+    @DisplayName(value = "닉네임은 중복되어서는 안된다.")
+    @Test
+    void duplicateNicknameTest() {
+        SignUpRequestDto dto1 = new SignUpRequestDto("username1", "password1!", "password1!",
+              "user1", null);
+        SignUpRequestDto dto2 = new SignUpRequestDto("username2", "password1!", "password1!",
+              "user1", null);
+
+        Assertions.assertThatNoException().isThrownBy(() -> userService.signUp(dto1));
+        Assertions.assertThatIllegalArgumentException().isThrownBy(() -> userService.signUp(dto2))
+              .withMessageContaining("닉네임");
+
+    }
+}


### PR DESCRIPTION
- 회원 도메인 생성
    - username, nickname 인덱스 설정
    - 예약어 이슈로 인해 테이블명 users으로 변경
- 회원가입 테스트 코드 구현 완료.
    - 아이디는 이메일 형식이고, 중복 금지 구현완료.
    - 비밀번호는 8자 이상 + (영문+ 숫자 + 특수문자) 포함 구현완료.
    - 비밀번호와 비밀번호 재확인이 일치여부 확인 구현완료.
    - 닉네임은 중복 금지 구현완료.

#ISSUE 3