### PR TITLE
[email-certification] email 인증방식 변경

### DIFF
--- a/src/main/java/com/miniproject/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/miniproject/config/security/WebSecurityConfig.java
@@ -7,6 +7,7 @@ import com.miniproject.config.security.handler.CustomLogoutSuccessHandler;
 import com.miniproject.config.security.handler.RedisLogoutHandler;
 import com.miniproject.config.security.jwt.JWTUtil;
 import com.miniproject.config.security.jwt.JwtCheckFilter;
+import com.miniproject.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -30,7 +31,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final LoginService loginService;
-//    private final JWTUtil h2JwtUtil;
+    private final UserRepository userRepository;
     private final JWTUtil redisJwtUtil;
 
     @Bean
@@ -63,7 +64,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
               .authorizeRequests(request ->
                     request
                           .antMatchers("/").permitAll()
-                          .antMatchers("/user/login", "/user/signup").anonymous()
+                          .antMatchers("/user/login", "/user/signup", "/user/certification").anonymous()
                           .anyRequest().authenticated())
               .addFilterAt(formLoginFilter, UsernamePasswordAuthenticationFilter.class)
               .addFilterAt(jwtCheckFilter, BasicAuthenticationFilter.class);
@@ -75,7 +76,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public FormLoginProvider formLoginProvider() {
-        return new FormLoginProvider(loginService, passwordEncoder());
+        return new FormLoginProvider(loginService, userRepository, passwordEncoder());
     }
 
     @Bean

--- a/src/main/java/com/miniproject/config/security/formLogin/FormLoginProvider.java
+++ b/src/main/java/com/miniproject/config/security/formLogin/FormLoginProvider.java
@@ -1,20 +1,27 @@
 package com.miniproject.config.security.formLogin;
 
+import com.miniproject.user.domain.User;
+import com.miniproject.user.domain.UserStatus;
+import com.miniproject.user.repository.UserRepository;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class FormLoginProvider implements AuthenticationProvider {
 
     private final LoginService loginService;
+    private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public FormLoginProvider(LoginService loginService, PasswordEncoder passwordEncoder) {
+    public FormLoginProvider(LoginService loginService, UserRepository userRepository,
+          PasswordEncoder passwordEncoder) {
         this.loginService = loginService;
+        this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
     }
 
@@ -23,6 +30,13 @@ public class FormLoginProvider implements AuthenticationProvider {
           throws AuthenticationException {
         String username = (String) authentication.getPrincipal();
         String password = (String) authentication.getCredentials();
+
+        User user = userRepository.findByUsername(username)
+              .orElseThrow(() -> new UsernameNotFoundException("잘못된 로그인 정보입니다."));
+
+        if (user.getUserStatus() == UserStatus.NOT_VALID) {
+            throw new IllegalStateException("인증이 완료되지 않은 계정입니다. 이메일 인증을 수행해주세요");
+        }
 
         UserDetails userDetails = loginService.loadUserByUsername(username);
 

--- a/src/main/java/com/miniproject/email/SignUpEmail.java
+++ b/src/main/java/com/miniproject/email/SignUpEmail.java
@@ -7,26 +7,30 @@ public class SignUpEmail implements SendingEmailFuc{
 
     private final String certificationCode;
     private final String charSet = "utf-8";
+    private final String url;
+    private final String email;
+    private final String authKey;
 
-    public SignUpEmail(String certificationCode) {
+    public SignUpEmail(String certificationCode, String url, String email, String authKey) {
         this.certificationCode = certificationCode;
+        this.url = url;
+        this.email = email;
+        this.authKey = authKey;
     }
 
+    @Override
     public void fillMessage(MimeMessage message) {
         try {
-            message.setSubject("가입 인증 메일 - 혜림스 포토존", charSet);
+            message.setSubject("회원가입 이메일 인증 - 혜림스 포토존", charSet);
 
-            message.setText("<!DOCTYPE html>\n"
-                  + "<html lang=\"UTF-8\">\n"
-                  + "<head>\n"
-                  + "    <meta charset=\"UTF-8\">\n"
-                  + "    <title></title>\n"
-                  + "</head>\n"
-                  + "<body>\n"
-                  + "<h1>가입을 환영합니다!!!</h1>\n"
-                  + "인증코드: " + certificationCode
-                  + "</body>\n"
-                  + "</html>", charSet, "html");
+            message.setText(new StringBuffer().append("<h1>[이메일 인증]</h1>")
+                  .append("<p>아래 링크를 클릭하시면 이메일 인증이 완료됩니다.</p>")
+                  .append("<a href='" + url + "/user/certification?email=")
+                  .append(email)
+                  .append("&authKey=")
+                  .append(authKey)
+                  .append("' target='_blenk'>이메일 인증 확인</a>")
+                  .toString(), charSet, "html");
         } catch (MessagingException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/miniproject/user/controller/UserController.java
+++ b/src/main/java/com/miniproject/user/controller/UserController.java
@@ -1,9 +1,9 @@
 package com.miniproject.user.controller;
 
 import com.miniproject.config.security.jwt.JWTUtil;
-import com.miniproject.user.dto.CertificationCodeDto;
 import com.miniproject.user.dto.SignUpRequestDto;
 import com.miniproject.user.service.UserService;
+import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
@@ -31,26 +31,19 @@ public class UserController {
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<String> signUp(@RequestBody SignUpRequestDto dto) {
+    public ResponseEntity<String> signUp(HttpServletRequest request, @RequestBody SignUpRequestDto dto) {
         userService.signUp(dto);
+        userService.createCertificationCode(dto.getUsername(), request.getRequestURL().toString().replace(request.getRequestURI(), ""));
         return ResponseEntity
               .status(HttpStatus.CREATED)
               .body("회원가입 완료!");
     }
 
     @GetMapping("/certification")
-    public ResponseEntity<String> requestCode(String email) {
-        userService.requestCertificationCode(email);
+    public ResponseEntity<String> requestCode(String email, String authKey) {
+        userService.verityEmail(email, authKey);
         return ResponseEntity
               .status(HttpStatus.OK)
-              .body("이메일 전송 완료!");
-    }
-
-    @PostMapping("/certification")
-    public ResponseEntity<String> certification(@RequestBody CertificationCodeDto dto) {
-        userService.checkCertificationCode(dto);
-        return ResponseEntity
-              .status(HttpStatus.OK)
-              .body("인증 완료!!");
+              .body("인증 완료!");
     }
 }

--- a/src/main/java/com/miniproject/user/domain/User.java
+++ b/src/main/java/com/miniproject/user/domain/User.java
@@ -5,6 +5,8 @@ import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -37,6 +39,10 @@ public class User {
     @Column(nullable = false, unique = true) private String nickname;
     private String profile;
 
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus userStatus;
+
     @Column(updatable = false) @CreatedDate private LocalDateTime createdAt;
     @Column(updatable = false) @CreatedBy private String createdBy;
     @Column(insertable = false) @LastModifiedDate private LocalDateTime updatedAt;
@@ -50,6 +56,11 @@ public class User {
         this.password = password;
         this.nickname = nickname;
         this.profile = profile;
+        this.userStatus = UserStatus.NOT_VALID;
+    }
+
+    public void changeStatus(UserStatus userStatus) {
+        this.userStatus = userStatus;
     }
 
 }

--- a/src/main/java/com/miniproject/user/domain/UserStatus.java
+++ b/src/main/java/com/miniproject/user/domain/UserStatus.java
@@ -1,0 +1,8 @@
+package com.miniproject.user.domain;
+
+public enum UserStatus {
+    NOT_VALID,
+    VALID,
+    WITHDRAW
+
+}

--- a/src/main/java/com/miniproject/user/dto/CertificationCodeDto.java
+++ b/src/main/java/com/miniproject/user/dto/CertificationCodeDto.java
@@ -1,10 +1,12 @@
 package com.miniproject.user.dto;
 
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class CertificationCodeDto {
 
     private String email;
-    private String code;
+    private String authKey;
 }


### PR DESCRIPTION
- 이메일 인증 코드에서 인증 링크 방식으로 변경
    - Redis를 사용해 일정 시간이 지나가면 인증 링크는 자동적으로 폐기
    - 계정과 인증키 모두 일치해야 인증 성공하는 방식으로 이루어짐.
- 계정 상태 추가 (UserStatus.java)
    - 계정 상태 추가로 미인증, 인증, 계정 삭제 여부를 확인할 수 있음.